### PR TITLE
토큰 에러 발생시 응답메시지 올바르게 내려주도록 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ gradle-app.setting
 ###Git submodule
 src/main/resources/application.yml
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,macos
+
+##query dsl
+**/generated

--- a/src/main/java/kr/doridos/dosticket/domain/auth/support/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/kr/doridos/dosticket/domain/auth/support/jwt/CustomAuthenticationEntryPoint.java
@@ -1,5 +1,9 @@
 package kr.doridos.dosticket.domain.auth.support.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.doridos.dosticket.exception.ErrorCode;
+import kr.doridos.dosticket.exception.ErrorResponse;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -12,6 +16,16 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        setErrorResponse(response, ErrorCode.TOKEN_NOT_FOUND.getMessage(), ErrorCode.TOKEN_NOT_FOUND);
+    }
+
+    public void setErrorResponse(HttpServletResponse response, String message, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/src/main/java/kr/doridos/dosticket/exception/ErrorCode.java
+++ b/src/main/java/kr/doridos/dosticket/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     //Auth
     EXPIRED_AUTHORIZATION_TOKEN(400, "A001", "이미 만료된 토큰입니다."),
     INVALID_AUTHORIZATION_TOKEN(404, "A002", "유효하지 않은 토큰입니다."),
+    TOKEN_NOT_FOUND(400, "A003", "토큰이 존재하지 않습니다."),
     //Global
     INPUT_VALUE_INVALID(400, "G001", "유효하지 않은 입력입니다."),
     HTTP_METHOD_NOT_ALLOWED(405, "G002", "지원하지 않는 HTTP 요청입니다."),


### PR DESCRIPTION
- 유효하지 않은 토큰, 토큰 없이 요청을 보내는 경우에 대한 에러 응답메시지를 올바르게 내려주도록 수정
   resolve #54 

(필터는 dispatcher 앞단에서 발생하기 때문에 Exception Handler 쪽에서 에러를 처리할 수 없어 이 문제를 해결함)
 