### PR TITLE
카테고리, 날짜별 티켓 검색, 전체 티켓 검색 나누어져 있던 api를 하나로 통합

### DIFF
--- a/src/main/java/kr/doridos/dosticket/domain/ticket/controller/TicketController.java
+++ b/src/main/java/kr/doridos/dosticket/domain/ticket/controller/TicketController.java
@@ -29,23 +29,13 @@ public class TicketController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/date")
-    public ResponseEntity<Page<TicketPageResponse>> findTicketsByStartDate(@RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate startDate,
-                                                                           @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate endDate,
-                                                                           final Pageable pageable) {
-        return ResponseEntity.ok(ticketService.findTicketsByDate(startDate, endDate, pageable));
-    }
-
     @GetMapping
-    public ResponseEntity<Page<TicketPageResponse>> findAllTicketsWithPaging(
-            @PageableDefault(size = 10, page = 0) final Pageable pageable) {
-        return ResponseEntity.ok(ticketService.findAllTickets(pageable));
-    }
+    public Page<TicketPageResponse> getFilteredTickets(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate endDate,
+            @RequestParam(required = false) final Long categoryId,
+            final Pageable pageable) {
 
-    @GetMapping("/category/{categoryId}")
-    public ResponseEntity<Page<TicketPageResponse>> findTicketsByCategoryId (
-            @PathVariable("categoryId") final Long categoryId,
-            @PageableDefault(size = 10, page = 0) final Pageable pageable) {
-        return ResponseEntity.ok(ticketService.findTicketsByCategoryId(categoryId, pageable));
+        return ticketService.getFilteredTickets(startDate, endDate, categoryId, pageable);
     }
 }

--- a/src/main/java/kr/doridos/dosticket/domain/ticket/repository/TicketCustomRepository.java
+++ b/src/main/java/kr/doridos/dosticket/domain/ticket/repository/TicketCustomRepository.java
@@ -5,11 +5,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public interface TicketCustomRepository {
 
-    Page<TicketPageResponse> findTicketsByCategoryId(Long categoryId, Pageable pageable);
-
-    Page<TicketPageResponse> findTicketsByStartDateBetween(LocalDate startDate, LocalDate endDate, Pageable pageable);
+    Page<TicketPageResponse> findFilteredTickets(LocalDate startDate, LocalDate endDate, Long categoryId, Pageable pageable);
 
 }

--- a/src/main/java/kr/doridos/dosticket/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/kr/doridos/dosticket/domain/ticket/repository/TicketRepository.java
@@ -1,12 +1,7 @@
 package kr.doridos.dosticket.domain.ticket.repository;
 
 import kr.doridos.dosticket.domain.ticket.entity.Ticket;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketCustomRepository {
-
-    Page<Ticket> findAll(Pageable pageable);
-
 }

--- a/src/main/java/kr/doridos/dosticket/domain/ticket/service/TicketService.java
+++ b/src/main/java/kr/doridos/dosticket/domain/ticket/service/TicketService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Service
 public class TicketService {
@@ -26,24 +25,14 @@ public class TicketService {
     @Transactional(readOnly = true)
     public TicketInfoResponse ticketInfo(final Long ticketId) {
         final Ticket ticket = ticketRepository.findById(ticketId).orElseThrow(() -> {
-                    throw new TicketNotFoundException(ErrorCode.TICKET_NOT_FOUND);});
+            throw new TicketNotFoundException(ErrorCode.TICKET_NOT_FOUND); });
 
         return TicketInfoResponse.of(ticket);
     }
 
     @Transactional(readOnly = true)
-    public Page<TicketPageResponse> findTicketsByDate(final LocalDate startDate, final LocalDate endDate, final Pageable pageable) {
-        return ticketRepository.findTicketsByStartDateBetween(startDate, endDate, pageable);
-    }
-
-    @Transactional(readOnly = true)
-    public Page<TicketPageResponse> findAllTickets(final Pageable pageable) {
-        return ticketRepository.findAll(pageable)
-                .map(TicketPageResponse::convertToDto);
-    }
-
-    @Transactional(readOnly = true)
-    public Page<TicketPageResponse> findTicketsByCategoryId (final Long categoryId, final Pageable pageable) {
-        return ticketRepository.findTicketsByCategoryId(categoryId, pageable);
+    public Page<TicketPageResponse> getFilteredTickets(final LocalDate startDate, final LocalDate endDate, final Long categoryId, final Pageable pageable) {
+        final Page<TicketPageResponse> ticketPageResponses = ticketRepository.findFilteredTickets(startDate, endDate, categoryId, pageable);
+        return ticketPageResponses;
     }
 }

--- a/src/test/java/kr/doridos/dosticket/domain/ticket/controller/TicketControllerTest.java
+++ b/src/test/java/kr/doridos/dosticket/domain/ticket/controller/TicketControllerTest.java
@@ -87,7 +87,7 @@ public class TicketControllerTest {
     void 카테고리로_티켓_페이징_조회에_성공한다200() throws Exception {
         Long categoryId = TicketFixture.티켓_생성().getCategory().getId();
 
-        mockMvc.perform(get("/tickets/category/" + categoryId)
+        mockMvc.perform(get("/tickets?" + categoryId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(categoryId)))
                 .andExpect(status().isOk())
@@ -102,7 +102,7 @@ public class TicketControllerTest {
         String startDate = "startDate=2024-08-20";
         String endDate = "endDate=2024-08-20";
 
-        mockMvc.perform(get("/tickets/date?" + startDate + "&" + endDate)
+        mockMvc.perform(get("/tickets?" + startDate + "&" + endDate)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(document("ticketDatePaging",

--- a/src/test/java/kr/doridos/dosticket/domain/ticket/service/TicketServiceTest.java
+++ b/src/test/java/kr/doridos/dosticket/domain/ticket/service/TicketServiceTest.java
@@ -19,9 +19,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -95,26 +92,27 @@ public class TicketServiceTest {
         @Test
         void 티켓을_페이징_조회한다() {
             Pageable pageable = PageRequest.of(0, 10);
-            Page<Ticket> ticketPage = new PageImpl<>(tickets, pageable, tickets.size());
+            Page<TicketPageResponse> ticketPage = new PageImpl<>(ticketPageResponse, pageable, tickets.size());
 
-            given(ticketRepository.findAll(pageable)).willReturn(ticketPage);
-            Page<TicketPageResponse> result = ticketService.findAllTickets(pageable);
+            given(ticketRepository.findFilteredTickets(null, null, null, pageable)).willReturn(ticketPage);
+
+            Page<TicketPageResponse> result = ticketService.getFilteredTickets(null, null, null, pageable);
 
             assertSoftly(softly -> {
-                softly.assertThat(ticketPage.getTotalElements()).isEqualTo(result.getTotalElements());
-                softly.assertThat(ticketPage.getTotalPages()).isEqualTo(result.getTotalPages());
+                softly.assertThat(result).isNotNull();
+                softly.assertThat(result.getTotalElements()).isEqualTo(ticketPage.getTotalElements());
+                softly.assertThat(result.getTotalPages()).isEqualTo(ticketPage.getTotalPages());
             });
         }
-
 
         @Test
         void 부모카테고리로_티켓을_조회한다() {
             Pageable pageable = PageRequest.of(0, 10);
             Page<TicketPageResponse> ticketPage = new PageImpl<>(ticketPageResponse, pageable, tickets.size());
 
-            given(ticketRepository.findTicketsByCategoryId(parentCategory.getId(), pageable)).willReturn(ticketPage);
+            given(ticketRepository.findFilteredTickets(null, null, parentCategory.getId(), pageable)).willReturn(ticketPage);
 
-            Page<TicketPageResponse> result = ticketService.findTicketsByCategoryId(parentCategory.getId(), pageable);
+            Page<TicketPageResponse> result = ticketService.getFilteredTickets(null, null, parentCategory.getId(), pageable);
 
             assertSoftly(softly -> {
                 softly.assertThat(result.getTotalElements()).isEqualTo(2);
@@ -127,9 +125,9 @@ public class TicketServiceTest {
             Pageable pageable = PageRequest.of(0, 10);
             Page<TicketPageResponse> ticketPage = new PageImpl<>(List.of(ticketPageResponse.get(1)), pageable, tickets.size());
 
-            given(ticketRepository.findTicketsByCategoryId(childCategory.getId(), pageable)).willReturn(ticketPage);
+            given(ticketRepository.findFilteredTickets(null, null, childCategory.getId(), pageable)).willReturn(ticketPage);
 
-            Page<TicketPageResponse> result = ticketService.findTicketsByCategoryId(childCategory.getId(), pageable);
+            Page<TicketPageResponse> result = ticketService.getFilteredTickets(null, null, childCategory.getId(), pageable);
 
             assertSoftly(softly -> {
                 softly.assertThat(result.getTotalElements()).isEqualTo(1);
@@ -144,9 +142,9 @@ public class TicketServiceTest {
             LocalDate startDate = LocalDate.of(2000, 9, 10);
             LocalDate endDate = LocalDate.of(2100, 9, 10);
 
-            given(ticketRepository.findTicketsByStartDateBetween(startDate, endDate, pageable)).willReturn(ticketPage);
+            given(ticketRepository.findFilteredTickets(startDate, endDate, null, pageable)).willReturn(ticketPage);
 
-            Page<TicketPageResponse> result = ticketService.findTicketsByDate(startDate, endDate, pageable);
+            Page<TicketPageResponse> result = ticketService.getFilteredTickets(startDate, endDate, null, pageable);
 
             assertSoftly(softly -> {
                 softly.assertThat(result.getTotalElements()).isEqualTo(2);
@@ -160,9 +158,9 @@ public class TicketServiceTest {
             LocalDate startDate = LocalDate.of(2000, 9, 10);
             LocalDate endDate = LocalDate.of(2000, 9, 10);
 
-            given(ticketRepository.findTicketsByStartDateBetween(startDate, endDate, pageable)).willReturn(Page.empty(pageable));
+            given(ticketRepository.findFilteredTickets(startDate, endDate, null, pageable)).willReturn(Page.empty(pageable));
 
-            Page<TicketPageResponse> result = ticketService.findTicketsByDate(startDate, endDate, pageable);
+            Page<TicketPageResponse> result = ticketService.getFilteredTickets(startDate, endDate, null, pageable);
 
             assertSoftly(softly -> {
                 softly.assertThat(result.getTotalElements()).isEqualTo(0);


### PR DESCRIPTION
- 카테고리, 날짜별 티켓 검색, 전체 티켓 검색 나누어져 있던 api를 하나로 통합
- querydsl 수정
 resolve #79 